### PR TITLE
Update requirements-2.txt

### DIFF
--- a/comps/dataprep/requirements-2.txt
+++ b/comps/dataprep/requirements-2.txt
@@ -259,3 +259,5 @@ yarl==1.20.1
 zipp==3.23.0
 zstandard==0.23.0
 fuzzywuzzy==0.18.0
+levenshtein==0.27.1
+python-levenshtein==0.27.1


### PR DESCRIPTION
For removing a warning:  UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')

 + levenshtein==0.27.1
 + python-levenshtein==0.27.1 